### PR TITLE
Update hyper links in lecture templates to point to the python source code

### DIFF
--- a/Dictionaries.html
+++ b/Dictionaries.html
@@ -18,7 +18,7 @@
             memoize</a>
             the naive, recursive Fibonacci algorithm. Let's take a look at how to do that.
             <br>
-            <a href="https://github.com/gcallah/algorithms/blob/master/fibonacci.py">Here</a>
+            <a href="https://github.com/gcallah/algorithms/blob/master/python/fibonacci.py">Here</a>
             is the Fibonacci code, now including memo-ization.
         </p>
         <h2>Dictionaries</h2>
@@ -76,7 +76,7 @@
             <li> Downside: wastes space. If you have no idea how many possible
             keys you need, direct addressing is not a good choice.
             <br>For instance, if your key is an arbitrary string!
-            <li><a href="https://github.com/gcallah/algorithms/blob/master/hash.py">
+            <li><a href="https://github.com/gcallah/algorithms/blob/master/python/hash.py">
                 Example code here.
                 </a>
         </ul>
@@ -219,7 +219,7 @@
             </a>
             <br>Uses two hash functions to search array for key.
             <li><a
-                    href="https://github.com/gcallah/algorithms/blob/master/hash.py">
+                    href="https://github.com/gcallah/algorithms/blob/master/python/hash.py">
                     Source code here</a>.
         </ul>
         <h4>

--- a/Lecture2.html
+++ b/Lecture2.html
@@ -104,7 +104,7 @@ the iterative algorithm that fills the table going in the forward direction.
 Pointed out how to reduce space to constant.
 </p>
 <p>
-<a href="https://github.com/gcallah/algorithms/blob/master/fibonacci.py">
+<a href="https://github.com/gcallah/algorithms/blob/master/python/fibonacci.py">
     Naive and faster Fibonacci code.</a>
 </p>
 <p>

--- a/Lecture3.html
+++ b/Lecture3.html
@@ -18,7 +18,7 @@
             memoize</a>
             the naive, recursive Fibonacci algorithm. Let's take a look at how to do that.
             <br>
-            <a href="https://github.com/gcallah/algorithms/blob/master/fibonacci.py">Here</a>
+            <a href="https://github.com/gcallah/algorithms/blob/master/python/fibonacci.py">Here</a>
             is the Fibonacci code, now including memo-ization.
         </p>
         <h2>Dictionaries</h2>
@@ -76,7 +76,7 @@
             <li> Downside: wastes space. If you have no idea how many possible
             keys you need, direct addressing is not a good choice.
             <br>For instance, if your key is an arbitrary string!
-            <li><a href="https://github.com/gcallah/algorithms/blob/master/hash.py">
+            <li><a href="https://github.com/gcallah/algorithms/blob/master/python/hash.py">
                 Example code here.
                 </a>
         </ul>
@@ -219,7 +219,7 @@
             </a>
             <br>Uses two hash functions to search array for key.
             <li><a
-                    href="https://github.com/gcallah/algorithms/blob/master/hash.py">
+                    href="https://github.com/gcallah/algorithms/blob/master/python/hash.py">
                     Source code here</a>.
         </ul>
         <h4>

--- a/Rand.html
+++ b/Rand.html
@@ -22,7 +22,7 @@
         </h2>
 
         <p>
-        <a href="https://github.com/gcallah/algorithms/blob/master/rand.py">
+        <a href="https://github.com/gcallah/algorithms/blob/master/python/rand.py">
             Source code here.
         </a>
         </p>


### PR DESCRIPTION
The hyper links in the Lecture templates are no longer valid as the Python code is moved into a `python` subfolder during this commit https://github.com/gcallah/algorithms/commit/fe8cee383088573d4a23dad1faff1abdc3b619f2