### PR TITLE
The Small-O and Small-Omega notations should be asymptotically tight

### DIFF
--- a/Lecture1.html
+++ b/Lecture1.html
@@ -262,7 +262,7 @@
                         asymptotically
                     </td>
                     <td>
-                        <em>f(n) <= k*g(n)</em> for every positive <em>k</em>
+                        <em>f(n) < k*g(n)</em> for every positive <em>k</em>
                     </td>
                 </tr>
             </table>
@@ -291,7 +291,7 @@
                         asymptotically
                     </td>
                     <td>
-                        <em>f(n) >= k*g(n)</em> for every positive <em>k</em>
+                        <em>f(n) > k*g(n)</em> for every positive <em>k</em>
                     </td>
                 </tr>
             </table>


### PR DESCRIPTION
> `Small-O` and `Small-omega` should be tight bounds, so the equality should not hold. 
> CLRS 3rd Edition `Page:50, 51` has those equations.