### PR TITLE
Modify travis to fetch ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - '3.5'
 before_install:
+  - rvm install ruby 2.0.0p648
+  - rvm use 2.0.0
   - bundle install
   - pip3 install pytest
 script: source run_ruby_and_python_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - '3.5'
 before_install:
   - rvm install 2.0.0-p648
-  - rvm use 2.0.0
   - bundle install
   - pip3 install pytest
 script: source run_ruby_and_python_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 python:
   - '3.5'
 before_install:
-  - \curl -sSL https://get.rvm.io | bash
-  - source ~/.rvm/scripts/rvm
-  - type rvm | head -n 1
-  - rvm install 2.0.0p648
+  # - \curl -sSL https://get.rvm.io | bash
+  # - source ~/.rvm/scripts/rvm
+  # - type rvm | head -n 1
+  - rvm install 2.0.0-p648
   - rvm use 2.0.0
   - bundle install
   - pip3 install pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ language: python
 python:
   - '3.5'
 before_install:
-  - rvm install ruby 2.0.0p648
-  - rvm use 2.0.0
+  - sudo apt-get install python-software-properties
+  - sudo apt-add-repository ppa:brightbox/ruby-ng
+  - sudo apt-get update
+  - sudo apt-get install ruby2.0.0 ruby-switch
+  - sudo ruby-switch --set ruby2.0.0
   - bundle install
   - pip3 install pytest
 script: source run_ruby_and_python_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - '3.5'
 before_install:
-  - \curl -sSL https://get.rvm.io | bash -s stable --ruby
+  - \curl -sSL https://get.rvm.io | bash
   - source ~/.rvm/scripts/rvm
   - type rvm | head -n 1
   - rvm install 2.0.0p648

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ before_install:
   - \curl -sSL https://get.rvm.io | bash -s stable --ruby
   - source ~/.rvm/scripts/rvm
   - type rvm | head -n 1
+  - rvm install 2.0.0p648
+  - rvm use 2.0.0
   - bundle install
   - pip3 install pytest
 script: source run_ruby_and_python_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@ language: python
 python:
   - '3.5'
 before_install:
-  - sudo apt-get install python-software-properties
-  - sudo apt-add-repository ppa:brightbox/ruby-ng
-  - sudo apt-get update
-  - sudo apt-get install ruby2.0.0 ruby-switch
-  - sudo ruby-switch --set ruby2.0.0
+  - \curl -sSL https://get.rvm.io | bash -s stable --ruby
+  - source ~/.rvm/scripts/rvm
+  - type rvm | head -n 1
   - bundle install
   - pip3 install pytest
 script: source run_ruby_and_python_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 python:
   - '3.5'
 before_install:
-  # - \curl -sSL https://get.rvm.io | bash
-  # - source ~/.rvm/scripts/rvm
-  # - type rvm | head -n 1
   - rvm install 2.0.0-p648
   - rvm use 2.0.0
   - bundle install


### PR DESCRIPTION
In order to have `refinements` in the ruby codebase, 2.0.0 is a must.